### PR TITLE
correct syntax error in routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,10 +3,10 @@ Rails.application.routes.draw do
   root to: 'pages#home'
   resources :games, only: [:new, :create, :edit, :update, :show] do
     member do
-      get :solution :results
+      get :solution
+      get :results
     end
   end
   resources :playlist, only: [:index]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end
-u_id string


### PR DESCRIPTION
après ticket avec Sunny, on a corrigé une erreur de syntaxe dans les routes (il fallait faire deux lignes get dans member)
    member do
      get :solution
      get :results
    end